### PR TITLE
compatible nacos 1.1.x  namespace

### DIFF
--- a/nacos/domain_updater.go
+++ b/nacos/domain_updater.go
@@ -12,24 +12,23 @@
  */
 
 package nacos
+
 import (
 	"sync"
 )
 
-var domCache =  DomCache{}
+var domCache = DomCache{}
 var AllDoms AllDomsMap
 var indexMap = NewConcurrentMap()
 var serverManger = ServerManager{}
 
 type AllDomsMap struct {
-	Data map[string]bool
+	Data         map[string]bool
 	CacheSeconds int
-	DLock sync.RWMutex
+	DLock        sync.RWMutex
 }
 
 type AllDomNames struct {
-	Doms []string `json:"doms"`
-	CacheMillis int `json:"cacheMillis"`
+	Doms  map[string][]string `json:"doms"`
+	Count int                 `json:"count"`
 }
-
-


### PR DESCRIPTION
nacos 1.3.x, api /nacos/v1/ns/api/allDomNames return value structure has changed. It's doms is a object that namespace as key domain as values.

PS: In my MBP, OS 10.15,  I change `sed` to `gsed` for build. 

When I use`sed` it gives me the error:
> command i expects \ followed by text.

1. `brew install gnu-sed`
2. change build.sh content:  `sed` to `gsed`
3. build: sh build.sh

then enjoy it!
